### PR TITLE
Measure the instantaneus power consumption

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,20 @@
+# POWER CONSUMPTION MONITORING SYSTEM OVERVIEW
+<img width="1103" alt="general-diagram" src="https://github.com/user-attachments/assets/7974267b-00f0-41fb-8ff0-f4c4d21e98f6">
+
+LOAD SPECS:
+- V_load: $24[V] \div 48[V]$
+- I_load: $-3[A] \div 25[A]$
+
+MONITORING SYSTEM SPECS:
+- V_monitor: $9[V] \div 17[V]$
+- Normally open relay connected in series with the load
+- Hall effect sensor chosen from the _Allegro ACS781xLR_ family
+
+## ASSIGNMENT
+I have to develop an overconsumption monitoring system (**monitor**) to perform plauysibility checks of a secondary system (**load**).
+The system must ensure that the load power supply is interrupted as soon as a consumption greater than 500W is detected.
+I decide to divide the development of the board into the following steps:
+- Measure the instantaneus power consumption.
+- Compare the instantaneus power consumption with the maximum allowed threshold.
+- Interrupt the load's power supply when the power consumption exceeds 500 W using the realy.
+- Ensure that the circuit cannot supply the load again, after the suplly has been interrupted once for a overconsumprion, until the whole system is turned off and back-ON.


### PR DESCRIPTION
Starting from the first step, in this pull i will develop the **Power measuring circuit**.
In order to acquire the instantaneous power consumption of the LOAD the only advised that is given si to use a Hall effect sensor form the Allegro ACS781xLR family. 
Exploring KiCad's lybrary i decided to use the ACS781xLRTR-050B because it's able to measure bi-direcional currents up to 50A.
Through the component datasheet, some prior knowledge and information found online I arrived at this first connection version:
![Hall-Effect_sensor](https://github.com/user-attachments/assets/2137239e-f92a-42b9-bef5-f6d450ac746b)
So now I have an instantaneous measurement of the current going to the load, but this is not enough to have a measurement of the power. 
in fact, knowing P = V*I, I also need the value of the voltage at which the load is being powered at that moment given that the power supply is a variable voltage supply.
To measure the V_load i designed a voltage divider that gives me signal ( ranging from 2.5 V to 5V ) proportional to voltage:
- At V_load = 24V --> it give's 2.5 V;
- At V_load = 48V --> it give's  5V;

![Voltage_divider](https://github.com/user-attachments/assets/1a11c030-f4b7-48fe-8821-c68a5dcb864a)

![calcoli_voltage_divider](https://github.com/user-attachments/assets/a3322625-66bc-4f76-9b22-6603b72f9cbb)

Instantaneous Power Calculation:
I use an analog multiplier (MPY634KU) to calculate the product  𝑃=𝑉⋅𝐼, this is the configuration i designed:

![Multiplier_MPY634KU](https://github.com/user-attachments/assets/b3fc9d13-7e03-403c-b68e-ed20364f4085)

As you can see i needed to use a dual power to supply this component and here is the way i got it:

![Alim_duale](https://github.com/user-attachments/assets/bfeed407-97de-40d4-a459-d199f736c9c1)

At this point I have obtained a constant measurement of power consumption and I can continue to the second step.
