### PR TITLE
Compare the instantaneus power consumption with the maximum allowed threshold.md

### DIFF
--- a/COMMITS.md
+++ b/COMMITS.md
@@ -1,0 +1,20 @@
+# POWER CONSUMPTION MONITORING SYSTEM OVERVIEW
+<img width="1103" alt="general-diagram" src="https://github.com/user-attachments/assets/7974267b-00f0-41fb-8ff0-f4c4d21e98f6">
+
+LOAD SPECS:
+- V_load: $24[V] \div 48[V]$
+- I_load: $-3[A] \div 25[A]$
+
+MONITORING SYSTEM SPECS:
+- V_monitor: $9[V] \div 17[V]$
+- Normally open relay connected in series with the load
+- Hall effect sensor chosen from the _Allegro ACS781xLR_ family
+
+## ASSIGNMENT
+I have to develop an overconsumption monitoring system (**monitor**) to perform plauysibility checks of a secondary system (**load**).
+The system must ensure that the load power supply is interrupted as soon as a consumption greater than 500W is detected.
+I decide to divide the development of the board into the following steps:
+- Measure the instantaneus power consumption.
+- Compare the instantaneus power consumption with the maximum allowed threshold.
+- Interrupt the load's power supply when the power consumption exceeds 500 W using the realy.
+- Ensure that the circuit cannot supply the load again, after the suplly has been interrupted once for a overconsumprion, until the whole system is turned off and back-ON.


### PR DESCRIPTION
Comparison with Maximum Power (𝑃𝑚𝑎𝑥=500 W):
I calculate the multiplier’s output signal when the consumption is at 500 W to verify that it matches approximately the same value either at V_load = 24V or at V_load = 48V and it matches at 2 V.
So I built a circuit that would generate a fixed 2V reference signal:

![V_rif = 2V](https://github.com/user-attachments/assets/d912853b-52ad-4614-8e45-e4f0f381044c)

This signal will be used as the V_rif threshold in a comparator that will detect when the power consumption goes over 500 W.
To build the coparator I've used an AO LM358P in the following configuration:

![comparator_LM358](https://github.com/user-attachments/assets/7d556b36-e8eb-41a6-b541-264bd4dc3b00)
![Comparator_specs](https://github.com/user-attachments/assets/395785cb-c1ea-4227-b96e-e316a396df7b)
